### PR TITLE
leverage the power of the flexbox layout

### DIFF
--- a/src/app/stylesheets/_custom.scss
+++ b/src/app/stylesheets/_custom.scss
@@ -437,7 +437,7 @@ md-toolbar {
 
 }
 .customtoolbar {
-  box-shadow: 0px 0px 15px 2px rgba(0,0,0,0.9);
+  box-shadow: 0px 0px 5px 2px rgba(0,0,0,0.9);
 }
 
 

--- a/src/app/views/tracks.html
+++ b/src/app/views/tracks.html
@@ -1,6 +1,6 @@
-<div layout="row" ng-app="app" layout-fill>
+
 <div layout-gt-md="row">
-  <md-card  class="card card-4-50-new" md-theme-watch style="min-width:600px;min-height:700px;max-width:611px">
+  <md-card md-theme-watch flex>
     <md-toolbar md-theme="custom" class="md-hue-1 md-whiteframe-z2" md-scroll-shrink ng-if="true">
       <div class="md-toolbar-tools">
         <h3>
@@ -34,7 +34,7 @@
     </md-content>
   </md-card-content>
 </md-card>
-<md-card md-theme="{{ showDarkTheme ? 'dark-grey' : 'default' }}" class="card card-4-50" style="height:550px;max-width:540px" md-theme-watch>
+<md-card md-theme="{{ showDarkTheme ? 'dark-grey' : 'default' }}" md-theme-watch>
   <md-toolbar md-theme="custom" class="md-hue-1 md-whiteframe-z2" md-scroll-shrink ng-if="true">
     <div class="md-toolbar-tools">
       <h3>
@@ -54,7 +54,6 @@
 </md-card>
 
 
-</div>
 </div>
 
 


### PR DESCRIPTION
@naveenjafer I adjusted the `tracks.html` in order to fill the horizontal space. This can all be done with the mighty `flex` attribute.

the `md-card` with the `flex` take all available horizontal space while the other card (the preview image) only takes the required space.

I also decreased the shadow of the top bar, imho this looks more natural :)
